### PR TITLE
fix: use format macros to print integers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ $(CORE)/%.o: $(CORE)/%.c
 
 .PHONY: format
 format:
-	clang-format -i **/*.c **/*.h
+	clang-format -style=file:.clang-format -i **/*.c **/*.h
 
 .PHONY: clean
 clean:

--- a/bin/hex2double.c
+++ b/bin/hex2double.c
@@ -13,13 +13,18 @@ int main(int argc, char **argv) {
 		char *hex = argv[i];
 		f64 number;
 
-		sscanf(hex, "%llX", (u64 *)&number);
+		sscanf(hex, "%" PRIx64 "", (u64 *)&number);
 
 		u64 *hex_number = (u64 *)&number;
 		Float f = decode_f64(number);
 
 		printf(
-			"%llX: %hhd x %lf x 2^%lld = %f\n", *hex_number, f.sign, f.m, f.exponent, number
+			"%" PRIx64 ": %hhd x %lf x 2^%" PRId64 " = %f\n",
+			*hex_number,
+			f.sign,
+			f.m,
+			f.exponent,
+			number
 		);
 	}
 }

--- a/bin/hex2float.c
+++ b/bin/hex2float.c
@@ -19,7 +19,12 @@ int main(int argc, char **argv) {
 		Float f = decode_f32(number);
 
 		printf(
-			"%X: %hhd x %lf x 2^%lld = %f\n", *hex_number, f.sign, f.m, f.exponent, number
+			"%X: %hhd x %lf x 2^%" PRId64 " = %f\n",
+			*hex_number,
+			f.sign,
+			f.m,
+			f.exponent,
+			number
 		);
 	}
 }

--- a/bin/snake.c
+++ b/bin/snake.c
@@ -191,7 +191,8 @@ bool position_out_of_screen(Position position) {
 Position random_fruit(Snake *snake) {
 	while (true) {
 		Position fruit = {
-			UNIT * random_range(0, N_WIDTH), UNIT * random_range(0, N_HEIGHT)};
+			UNIT * random_range(0, N_WIDTH), UNIT * random_range(0, N_HEIGHT)
+		};
 
 		if (snake_contains(snake, fruit))
 			continue;

--- a/bin/snake.c
+++ b/bin/snake.c
@@ -191,8 +191,7 @@ bool position_out_of_screen(Position position) {
 Position random_fruit(Snake *snake) {
 	while (true) {
 		Position fruit = {
-			UNIT * random_range(0, N_WIDTH), UNIT * random_range(0, N_HEIGHT)
-		};
+			UNIT * random_range(0, N_WIDTH), UNIT * random_range(0, N_HEIGHT)};
 
 		if (snake_contains(snake, fruit))
 			continue;

--- a/src/wheel/core/types.h
+++ b/src/wheel/core/types.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 typedef uint8_t u8;
 typedef int8_t i8;


### PR DESCRIPTION
macos下输出u64是lld，而一般的Linux平台用的是ld，可以使用PRId64这个宏兼容